### PR TITLE
keep the local build objects out of the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,8 @@
 .dockerignore
 .git
+.github
 .gitignore
 ci/
+*.dep
+*.lo
+*.o


### PR DESCRIPTION
The image is fine for CI runs, but when building locally for testing, the generated files were being copied to the image. Added the generated files to .gitignore.