### PR TITLE
Make ready for PHP 8.2 Compatibility

### DIFF
--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -17,11 +17,10 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
-          - "8.2.0RC1"
     steps:
       - name: checkout
         uses: actions/checkout@v3
       - name: build
-        run: docker build -t local -f ci/Dockerfile . --build-arg PHP_VERSION=${{ matrix.version }}
+        run: docker build -t local -f ci/Dockerfile . --build-arg PHP_VERSION=${{ matrix.version }} --target test
       - name: test
         run: docker run local

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -21,6 +21,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: build
-        run: docker build -t local -f ci/Dockerfile . --build-arg PHP_VERSION=${{ matrix.version }} --target=test
+        run: docker build -t local -f ci/Dockerfile . --build-arg PHP_VERSION=${{ matrix.version }} --target test
       - name: test
         run: docker run local

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -21,6 +21,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: build
-        run: docker build -t local -f ci/Dockerfile . --build-arg PHP_VERSION=${{ matrix.version }} --target test
+        run: docker build -t local -f ci/Dockerfile . --build-arg PHP_VERSION=${{ matrix.version }} --target=test
       - name: test
         run: docker run local

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,11 +1,37 @@
 ARG PHP_VERSION="8.1-buster"
 
-FROM php:${PHP_VERSION} as check-build-context
-WORKDIR /usr/share/check-build-context
-COPY . .
-ENTRYPOINT ["/bin/bash"]
 
-FROM php:${PHP_VERSION}
+###
+### check-build-context
+###
+FROM php:${PHP_VERSION} as check-build-context
+
+ARG EXA_VERSION=0.10.1
+
+RUN apt-get update && apt-get install -y \
+    unzip \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/share/exa
+RUN curl -sLO https://github.com/ogham/exa/releases/download/v${EXA_VERSION}/exa-linux-x86_64-v${EXA_VERSION}.zip \
+ && unzip exa-linux-x86_64-v${EXA_VERSION}.zip \
+ && cp bin/exa /usr/local/bin/ \
+ && cd .. \
+ && rm exa -r
+
+WORKDIR /usr/share/check-build-context
+
+# TODO: is the required-for-good-ux-in-windows-10 chmod problematic?
+COPY --chmod=0644 . .
+
+ENTRYPOINT ["/usr/local/bin/exa"]
+CMD ["--tree", "--level=10", "--icons", "--colour=always"]
+
+
+###
+### build
+###
+FROM php:${PHP_VERSION} as build
 
 RUN apt-get update && apt-get install -y \
     libxml2-dev \
@@ -22,7 +48,65 @@ RUN phpize \
 
 RUN docker-php-ext-enable mf2
 
+
+###
+### test
+###
+FROM build as test
+
 COPY tests tests/
 
 ENV REPORT_EXIT_STATUS=1
 CMD ["php", "./run-tests.php", "-P", "-q", "--show-diff"]
+
+
+###
+### dev-build
+###
+FROM php:${PHP_VERSION} as dev-build
+
+RUN apt-get update && apt-get install -y \
+    libxml2-dev \
+    gdb \
+    valgrind
+
+WORKDIR /usr/share/microformats
+COPY *.* ./
+
+RUN phpize \
+ && EXTRA_CFLAGS='-Wall -Wextra -Wno-unused-parameter' \
+    ./configure \
+ && make -j2 \
+ && make install
+
+RUN docker-php-ext-enable mf2
+
+
+###
+### dev-test
+###
+FROM dev-build as dev-test
+COPY tests tests/
+CMD ["/bin/bash"]
+
+
+###
+### dev-valgrind
+###
+FROM dev-test as dev-valgrind
+
+ENV ZEND_DONT_UNLOAD_MODULES=1
+ENV USE_ZEND_ALLOC=0
+
+CMD ["php", "./run-tests.php", "-m", "-P", "-q", "--show-diff"]
+
+###
+### dev-gdb
+###
+FROM dev-test as dev-gdb
+
+ENV ZEND_DONT_UNLOAD_MODULES=1
+ENV USE_ZEND_ALLOC=0
+
+ENTRYPOINT ["gdb"]
+CMD ["--args", "php", "-r", "echo PHP_EOL, ' -=-=-= hello, world! =-=-=-', PHP_EOL, PHP_EOL;"]

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -2,33 +2,6 @@ ARG PHP_VERSION="8.1-buster"
 
 
 ###
-### check-build-context
-###
-FROM php:${PHP_VERSION} as check-build-context
-
-ARG EXA_VERSION=0.10.1
-
-RUN apt-get update && apt-get install -y \
-    unzip \
- && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /usr/share/exa
-RUN curl -sLO https://github.com/ogham/exa/releases/download/v${EXA_VERSION}/exa-linux-x86_64-v${EXA_VERSION}.zip \
- && unzip exa-linux-x86_64-v${EXA_VERSION}.zip \
- && cp bin/exa /usr/local/bin/ \
- && cd .. \
- && rm exa -r
-
-WORKDIR /usr/share/check-build-context
-
-# TODO: is the required-for-good-ux-in-windows-10 chmod problematic?
-COPY --chmod=0644 . .
-
-ENTRYPOINT ["/usr/local/bin/exa"]
-CMD ["--tree", "--level=10", "--icons", "--colour=always"]
-
-
-###
 ### build
 ###
 FROM php:${PHP_VERSION} as build
@@ -110,3 +83,30 @@ ENV USE_ZEND_ALLOC=0
 
 ENTRYPOINT ["gdb"]
 CMD ["--args", "php", "-r", "echo PHP_EOL, ' -=-=-= hello, world! =-=-=-', PHP_EOL, PHP_EOL;"]
+
+
+###
+### check-build-context
+###
+FROM php:${PHP_VERSION} as check-build-context
+
+ARG EXA_VERSION=0.10.1
+
+RUN apt-get update && apt-get install -y \
+    unzip \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/share/exa
+RUN curl -sLO https://github.com/ogham/exa/releases/download/v${EXA_VERSION}/exa-linux-x86_64-v${EXA_VERSION}.zip \
+ && unzip exa-linux-x86_64-v${EXA_VERSION}.zip \
+ && cp bin/exa /usr/local/bin/ \
+ && cd .. \
+ && rm exa -r
+
+WORKDIR /usr/share/check-build-context
+
+# TODO: is the required-for-good-ux-in-windows-10 chmod problematic?
+COPY --chmod=0644 . .
+
+ENTRYPOINT ["/usr/local/bin/exa"]
+CMD ["--tree", "--level=10", "--icons", "--colour=always"]


### PR DESCRIPTION
The 8.2 release improves PHP and mf2 should incorporate the improvements, rather than rush to compatibility in a CI test.

This removes the 8.2.0RC1 build from CI.

I also added some extra build targets to the Dockerfile that will come in handy shortly.